### PR TITLE
Add customer-requested features

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -16,12 +16,12 @@ Using
 
 Some setting is require for this cleanup process.
 
-•	Setting Panel
+â€¢	Setting Panel
 Days of Inactivity is set by the admin user.
-Days Before Deletion is set with zero when admin just wants to notify the inactive user for access the site i.e. in first step. 
-After that when user wants to run cleanup process then Days Before Deletion will set by the admin user.
+Days Before Deletion is set with zero when admin just wants to notify the inactive user for access the site i.e. in first step. After that when user wants to run cleanup process then Days Before Deletion will set by the admin user.
+Ignore Disabled Users is set when admin wants to ignore users in the 'suspended' state when running the cleanup tool.
 
-•	Email setting
+â€¢	Email setting
 
 Admin user must set the subject and body text of the email.
 Cron process

--- a/email_form.php
+++ b/email_form.php
@@ -30,13 +30,18 @@ require_once($CFG->dirroot . '/user/editlib.php');
 class tool_inactive_user_cleanup_config_form extends moodleform {
     public function definition () {
         $mform = $this->_form;
+        
+        //Settings panel elements
         $mform->addElement('header', 'configheader', get_string('setting', 'tool_inactive_user_cleanup'));
         $mform->addElement('text', 'config_daysofinactivity', get_string('daysofinactivity', 'tool_inactive_user_cleanup'));
         $mform->addElement('text', 'config_daysbeforedeletion', get_string('daysbeforedeletion', 'tool_inactive_user_cleanup'));
+        $mform->addElement('advcheckbox','config_ignoredisabledusers', get_string('ignoredisabledusers', 'tool_inactive_user_cleanup'));
         $mform->setDefault('config_daysofinactivity', '365');
         $mform->setType('config_daysofinactivity', PARAM_TEXT);
         $mform->setDefault('config_daysbeforedeletion', '10');
         $mform->setType('config_daysbeforedeletion', PARAM_TEXT);
+        
+        // Email panel elements
         $mform->addElement('header', 'config_headeremail', get_string('emailsetting', 'tool_inactive_user_cleanup'));
         $mform->addElement('text', 'config_subjectemail', get_string('emailsubject', 'tool_inactive_user_cleanup'));
         $editoroptions = array('trusttext' => true, 'subdirs' => true, 'maxfiles' => 1,

--- a/lang/en/tool_inactive_user_cleanup.php
+++ b/lang/en/tool_inactive_user_cleanup.php
@@ -31,4 +31,4 @@ $string['emailsetting'] = 'Email Setting';
 $string['emailsubject'] = 'Subject';
 $string['emailbody'] = 'Body';
 $string['runcron'] = 'Run Cron Manually';
-
+$string['ignoredisabledusers'] = 'Ignore Disabled Users';

--- a/lib.php
+++ b/lib.php
@@ -31,11 +31,22 @@ has_capability('moodle/user:delete', context_system::instance());
 function tool_inactive_user_cleanup_cron() {
     global $DB, $CFG;
     mtrace("Hey, admin tool inactive user cleanup is running");
+    
+    //get config values from the databse 
     $beforedelete = get_config('tool_inactive_user_cleanup', 'daysbeforedeletion');
     $inactivity = get_config('tool_inactive_user_cleanup', 'daysofinactivity');
     $subject = get_config('tool_inactive_user_cleanup', 'emailsubject');
     $body = get_config('tool_inactive_user_cleanup', 'emailbody');
-    $users = $DB->get_records('user', array('deleted' => '0'));
+    $ignoredisabled = get_config('tool_inactive_user_cleanup', 'ignoredisabledusers');
+    
+    //retrieve user data
+    if ($ignoredisabled) {
+        $users = $DB->get_records('user', array('deleted' => '0', 'suspended' => '0'));
+    }
+    else {
+        $users = $DB->get_records('user', array('deleted' => '0'));
+    }
+    
     $messagetext = html_to_text($body);
     $mainadminuser = get_admin();
 


### PR DESCRIPTION
My workplace received a request from a customer to automate the deletion of old and stale users.

Once we installed the inactive_user_cleanup too we realized that there was not an ability to customize the email being sent on a per-user basis. The customer was used to the $a style personalization present in the core email facilities (powered by the string manager's `get_string()` method). This PR implements rudimentary support for this with a fixed set of replacement options that can be easily extended as needed by new users of the plugin.

While testing, we also identified a new requirement. The customer has users archived (with the built in user suspension) for support staff and students that are currently on leave. As such, those accounts should not be marked for expiry when they are in the 'suspended state'.
