### PR TITLE
Added enable setting to plugin

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="tool/inactive_user_cleanup/db" VERSION="20150420" COMMENT="XMLDB file for Moodle tool/inactive_user_cleanup"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+<XMLDB PATH="admin/tool/inactive_user_cleanup/db" VERSION="20150420"
+       COMMENT="XMLDB file for Moodle tool/inactive_user_cleanup"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
-  <TABLES>
-    <TABLE NAME="tool_inactive_user_cleanup" COMMENT="Admin Tool inactive_user_cleanup">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="userid"/>
-        <FIELD NAME="emailsent" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Is email sent or not"/>
-        <FIELD NAME="date" TYPE="char" LENGTH="500" NOTNULL="false" SEQUENCE="false" COMMENT="date of email sent"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-  </TABLES>
+    <TABLES>
+        <TABLE NAME="tool_inactive_user_cleanup" COMMENT="Admin Tool inactive_user_cleanup">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="userid"/>
+                <FIELD NAME="emailsent" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"
+                       COMMENT="Is email sent or not"/>
+                <FIELD NAME="date" TYPE="char" LENGTH="500" NOTNULL="false" SEQUENCE="false"
+                       COMMENT="date of email sent"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+    </TABLES>
 </XMLDB>

--- a/email_form.php
+++ b/email_form.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * From for Inactive user cleanup email setting 
+ * From for Inactive user cleanup email setting
  *
  * @package    tool
  * @subpackage Inactive User cleanup
@@ -24,13 +24,16 @@
  */
 
 defined('MOODLE_INTERNAL') || die();
-require_once($CFG->libdir.'/formslib.php');
+require_once($CFG->libdir . '/formslib.php');
 require_once($CFG->dirroot . '/user/editlib.php');
 
-class tool_inactive_user_cleanup_config_form extends moodleform {
-    public function definition () {
+class tool_inactive_user_cleanup_config_form extends moodleform
+{
+    public function definition()
+    {
         $mform = $this->_form;
         $mform->addElement('header', 'configheader', get_string('setting', 'tool_inactive_user_cleanup'));
+        $mform->addElement('select', 'config_enabled', get_string('enabled', 'tool_inactive_user_cleanup'), array(0 => get_string('disabled', 'tool_inactive_user_cleanup'), 1 => get_string('enabled', 'tool_inactive_user_cleanup')))->setSelected(0);
         $mform->addElement('text', 'config_daysofinactivity', get_string('daysofinactivity', 'tool_inactive_user_cleanup'));
         $mform->addElement('text', 'config_daysbeforedeletion', get_string('daysbeforedeletion', 'tool_inactive_user_cleanup'));
         $mform->setDefault('config_daysofinactivity', '365');
@@ -40,7 +43,7 @@ class tool_inactive_user_cleanup_config_form extends moodleform {
         $mform->addElement('header', 'config_headeremail', get_string('emailsetting', 'tool_inactive_user_cleanup'));
         $mform->addElement('text', 'config_subjectemail', get_string('emailsubject', 'tool_inactive_user_cleanup'));
         $editoroptions = array('trusttext' => true, 'subdirs' => true, 'maxfiles' => 1,
-        'maxbytes' => 1024);
+            'maxbytes' => 1024);
         $mform->addElement('editor', 'config_bodyemail', get_string('emailbody', 'tool_inactive_user_cleanup'), $editoroptions);
         $mform->setType('config_subjectemail', PARAM_TEXT);
         $mform->setDefault('config_subjectemail', 'subject');

--- a/index.php
+++ b/index.php
@@ -67,8 +67,9 @@ echo $OUTPUT->header();
 $emailform = new tool_inactive_user_cleanup_config_form();
 $fromdata = $emailform->get_data();
 $configdata = get_config('tool_inactive_user_cleanup');
-if(!empty($configdata->daysbeforedeletion)) {
+if(!empty($configdata->enabled) && !empty($configdata->daysbeforedeletion)) {
 	$data = new stdClass();
+	$data->config_enabled = $configdata->enabled;
 	$data->config_daysbeforedeletion = $configdata->daysbeforedeletion;
 	$data->config_daysofinactivity = $configdata->daysofinactivity;
 	$data->config_subjectemail = $configdata->emailsubject;
@@ -78,6 +79,7 @@ if(!empty($configdata->daysbeforedeletion)) {
 $emailform->display();
 
 if ($emailform->is_submitted()) {
+    set_config('enabled', $fromdata->config_enabled, 'tool_inactive_user_cleanup');
     set_config('daysbeforedeletion', $fromdata->config_daysbeforedeletion, 'tool_inactive_user_cleanup');
     set_config('daysofinactivity', $fromdata->config_daysofinactivity, 'tool_inactive_user_cleanup');
     set_config('emailsubject', $fromdata->config_subjectemail, 'tool_inactive_user_cleanup');

--- a/lang/en/tool_inactive_user_cleanup.php
+++ b/lang/en/tool_inactive_user_cleanup.php
@@ -31,3 +31,5 @@ $string['emailsetting'] = 'Email Setting';
 $string['emailsubject'] = 'Subject';
 $string['emailbody'] = 'Body';
 $string['runcron'] = 'Run Cron Manually';
+$string['enabled'] = 'Enabled';
+$string['disabled'] = 'Disabled';

--- a/lib.php
+++ b/lib.php
@@ -64,11 +64,13 @@ function tool_inactive_user_cleanup_cron() {
                 mtrace('days before delete'. strtotime('+'.$beforedelete.' day', $deleteuserafternotify->date));
                 $minus_timestamp = strtotime('+' . $minus .' days');
 
-                if (($minus_timestamp) >= ( strtotime('+'.$beforedelete.' day', $deleteuserafternotify->date) )) {
+                if (($minus_timestamp) >= ( strtotime('+'.$beforedelete.' day', $deleteuserafternotify->date) ) && $minus > $inactivity) {
                     if (!isguestuser($usersdetails->id)) {
                         delete_user($usersdetails);
                         mtrace('delete user' . $usersdetails->id);
                     }
+                } elseif($minus <= $inactivity) {
+                    $DB->delete_records('tool_inactive_user_cleanup', array('userid' => $usersdetails->id));
                 }
             }
         } 


### PR DESCRIPTION
This plugin is potentially dangerous. Before this adjustment users could potentially be deleted immediately after installing this plugin. So an extra "enable/disable" option in the settings of this plugin are welcome. 
This enable/disable config setting is checked before running the cron task.