### PR TITLE
14 Fix Fatal error: Namespace declaration...

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -22,7 +22,7 @@
  * @copyright DualCube (https://dualcube.com)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-defined('MOODLE_INTERNAL') || die();
+
 /*
  * Standard cron function
  */

--- a/classes/task/tool_inactive_user_cleanup_task.php
+++ b/classes/task/tool_inactive_user_cleanup_task.php
@@ -22,7 +22,7 @@
  * @copyright DualCube (https://dualcube.com)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-defined('MOODLE_INTERNAL') || die();
+
 /*
  * tool_inactive_user_cleanup is standard cron function
  */


### PR DESCRIPTION
PR for #14.

Removed defined('MOODLE_INTERNAL') || die(), these are extraneous in files which only contain class definitions, and must not appear before namespace declarations (a PHP Fatal Error occurs if they do).